### PR TITLE
RY-58 refactor: video card divide

### DIFF
--- a/src-ts/components/features/EnterVideosContent.tsx
+++ b/src-ts/components/features/EnterVideosContent.tsx
@@ -1,10 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 import { VideoItem } from '@/domain/Video';
 import EnterService from '@/service/EnterService';
-import VideoCard from '@/components/ui/VideoCard';
 import Error from '@/components/features/Error';
 import Loading from '@/components/features/Loading';
 import { getVideoIdOrChannelId } from '@/common/VideoUtil';
+import VideoCardContainer from '@/components/ui/VideoCardContainer';
+import VideoCard from '@/components/ui/VideoCard';
 
 const EnterVideosContent = () => {
   const { isLoading, error, data } = useQuery({
@@ -25,9 +26,9 @@ const EnterVideosContent = () => {
     <>
       {error && <Error />}
       {isLoading && <Loading />}
-      <ul className='grid grid-cols-1 gap-y-4 sm:grid-cols-2 sm:gap-x-4 sm:gap-y-10 lg:grid-cols-3 2xl:grid-cols-4'>
-        {data && data.map((item, index) => <VideoCard key={`enter-${index}`} video={item} style='' />)}
-      </ul>
+      <VideoCardContainer>
+        {data && data.map((item, index) => <VideoCard key={`enter-${index}`} video={item} />)}
+      </VideoCardContainer>
     </>
   );
 };

--- a/src-ts/components/features/EnterVideosContent.tsx
+++ b/src-ts/components/features/EnterVideosContent.tsx
@@ -5,7 +5,6 @@ import Error from '@/components/features/Error';
 import Loading from '@/components/features/Loading';
 import { getVideoIdOrChannelId } from '@/common/VideoUtil';
 import VideoCardContainer from '@/components/ui/VideoCardContainer';
-import VideoCard from '@/components/ui/VideoCard';
 
 const EnterVideosContent = () => {
   const { isLoading, error, data } = useQuery({
@@ -26,9 +25,7 @@ const EnterVideosContent = () => {
     <>
       {error && <Error />}
       {isLoading && <Loading />}
-      <VideoCardContainer>
-        {data && data.map((item, index) => <VideoCard key={`enter-${index}`} video={item} />)}
-      </VideoCardContainer>
+      {data && <VideoCardContainer videos={data} />}
     </>
   );
 };

--- a/src-ts/components/features/MusicVideosContent.tsx
+++ b/src-ts/components/features/MusicVideosContent.tsx
@@ -1,10 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 import { VideoItem } from '@/domain/Video';
 import MusicService from '@/service/MusicService';
-import VideoCard from '@/components/ui/VideoCard';
 import Error from '@/components/features/Error';
 import Loading from '@/components/features/Loading';
 import { getVideoIdOrPlaylistId } from '@/common/VideoUtil';
+import VideoCardContainer from '@/components/ui/VideoCardContainer';
+import VideoCard from '@/components/ui/VideoCard';
 
 const MusicVideosContent = () => {
   const { isLoading, error, data } = useQuery({
@@ -23,9 +24,9 @@ const MusicVideosContent = () => {
     <>
       {error && <Error />}
       {isLoading && <Loading />}
-      <ul className='grid grid-cols-1 gap-y-4 sm:grid-cols-2 sm:gap-x-4 sm:gap-y-10 lg:grid-cols-3 2xl:grid-cols-4'>
-        {data && data.map((item, index) => <VideoCard key={`music-${index}`} video={item} style='' />)}
-      </ul>
+      <VideoCardContainer>
+        {data && data.map((item, index) => <VideoCard key={`music-${index}`} video={item} />)}
+      </VideoCardContainer>
     </>
   );
 };

--- a/src-ts/components/features/MusicVideosContent.tsx
+++ b/src-ts/components/features/MusicVideosContent.tsx
@@ -5,7 +5,6 @@ import Error from '@/components/features/Error';
 import Loading from '@/components/features/Loading';
 import { getVideoIdOrPlaylistId } from '@/common/VideoUtil';
 import VideoCardContainer from '@/components/ui/VideoCardContainer';
-import VideoCard from '@/components/ui/VideoCard';
 
 const MusicVideosContent = () => {
   const { isLoading, error, data } = useQuery({
@@ -24,9 +23,7 @@ const MusicVideosContent = () => {
     <>
       {error && <Error />}
       {isLoading && <Loading />}
-      <VideoCardContainer>
-        {data && data.map((item, index) => <VideoCard key={`music-${index}`} video={item} />)}
-      </VideoCardContainer>
+      {data && <VideoCardContainer videos={data} />}
     </>
   );
 };

--- a/src-ts/components/features/NewsVideosContent.tsx
+++ b/src-ts/components/features/NewsVideosContent.tsx
@@ -1,10 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 import { VideoItem } from '@/domain/Video';
 import NewsService from '@/service/NewsService';
-import VideoCard from '@/components/ui/VideoCard';
 import Error from '@/components/features/Error';
 import Loading from '@/components/features/Loading';
 import { getVideoIdOrChannelId } from '@/common/VideoUtil';
+import VideoCardContainer from '@/components/ui/VideoCardContainer';
+import VideoCard from '@/components/ui/VideoCard';
 
 const NewsVideosContent = () => {
   const { isLoading, error, data } = useQuery({
@@ -23,9 +24,9 @@ const NewsVideosContent = () => {
     <>
       {isLoading && <Loading />}
       {error && <Error />}
-      <ul className='grid grid-cols-1 gap-y-4 sm:grid-cols-2 sm:gap-x-4 sm:gap-y-10 lg:grid-cols-3 2xl:grid-cols-4'>
-        {data && data.map((item, index) => <VideoCard key={`news-${index}`} video={item} style='' />)}
-      </ul>
+      <VideoCardContainer>
+        {data && data.map((item, index) => <VideoCard key={`news-${index}`} video={item} />)}
+      </VideoCardContainer>
     </>
   );
 };

--- a/src-ts/components/features/NewsVideosContent.tsx
+++ b/src-ts/components/features/NewsVideosContent.tsx
@@ -5,7 +5,6 @@ import Error from '@/components/features/Error';
 import Loading from '@/components/features/Loading';
 import { getVideoIdOrChannelId } from '@/common/VideoUtil';
 import VideoCardContainer from '@/components/ui/VideoCardContainer';
-import VideoCard from '@/components/ui/VideoCard';
 
 const NewsVideosContent = () => {
   const { isLoading, error, data } = useQuery({
@@ -24,9 +23,7 @@ const NewsVideosContent = () => {
     <>
       {isLoading && <Loading />}
       {error && <Error />}
-      <VideoCardContainer>
-        {data && data.map((item, index) => <VideoCard key={`news-${index}`} video={item} />)}
-      </VideoCardContainer>
+      {data && <VideoCardContainer videos={data} />}
     </>
   );
 };

--- a/src-ts/components/features/PopularVideosContent.tsx
+++ b/src-ts/components/features/PopularVideosContent.tsx
@@ -3,7 +3,6 @@ import PopularService from '@/service/PopularService';
 import Error from '@/components/features/Error';
 import Loading from '@/components/features/Loading';
 import VideoCardContainer from '@/components/ui/VideoCardContainer';
-import VideoCard from '@/components/ui/VideoCard';
 
 const PopularVideosContent = () => {
   const { isLoading, error, data } = useQuery({
@@ -18,9 +17,7 @@ const PopularVideosContent = () => {
     <>
       {isLoading && <Loading />}
       {error && <Error />}
-      <VideoCardContainer>
-        {data && data.map((item) => <VideoCard key={item.id} video={item} />)}
-      </VideoCardContainer>
+      {data && <VideoCardContainer videos={data} />}
     </>
   );
 };

--- a/src-ts/components/features/PopularVideosContent.tsx
+++ b/src-ts/components/features/PopularVideosContent.tsx
@@ -1,8 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
 import PopularService from '@/service/PopularService';
-import VideoCard from '@/components/ui/VideoCard';
 import Error from '@/components/features/Error';
 import Loading from '@/components/features/Loading';
+import VideoCardContainer from '@/components/ui/VideoCardContainer';
+import VideoCard from '@/components/ui/VideoCard';
 
 const PopularVideosContent = () => {
   const { isLoading, error, data } = useQuery({
@@ -17,9 +18,9 @@ const PopularVideosContent = () => {
     <>
       {isLoading && <Loading />}
       {error && <Error />}
-      <ul className='grid grid-cols-1 gap-y-4 sm:grid-cols-2 sm:gap-x-4 sm:gap-y-10 lg:grid-cols-3 2xl:grid-cols-4'>
-        {data && data.map((item) => <VideoCard key={item.id} video={item} style='' />)}
-      </ul>
+      <VideoCardContainer>
+        {data && data.map((item) => <VideoCard key={item.id} video={item} />)}
+      </VideoCardContainer>
     </>
   );
 };

--- a/src-ts/components/features/SearchVideosContent.tsx
+++ b/src-ts/components/features/SearchVideosContent.tsx
@@ -6,7 +6,6 @@ import Error from '@/components/features/Error';
 import Loading from '@/components/features/Loading';
 import { getVideoIdOrChannelId } from '@/common/VideoUtil';
 import VideoListContainer from '@/components/ui/VideoListContainer';
-import VideoList from '@/components/ui/VideoList';
 
 const SearchVideosContent = () => {
   const { keyword = '' } = useParams();
@@ -27,9 +26,7 @@ const SearchVideosContent = () => {
     <>
       {error && <Error />}
       {isLoading && <Loading />}
-      <VideoListContainer>
-        {data && data.map((item, index) => <VideoList key={`search-${index}`} video={item} />)}
-      </VideoListContainer>
+      {data && <VideoListContainer videos={data} />}
     </>
   );
 };

--- a/src-ts/components/features/SearchVideosContent.tsx
+++ b/src-ts/components/features/SearchVideosContent.tsx
@@ -2,10 +2,11 @@ import { useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { VideoItem } from '@/domain/Video';
 import SearchService from '@/service/SearchService';
-import VideoCard from '@/components/ui/VideoCard';
 import Error from '@/components/features/Error';
 import Loading from '@/components/features/Loading';
 import { getVideoIdOrChannelId } from '@/common/VideoUtil';
+import VideoListContainer from '@/components/ui/VideoListContainer';
+import VideoList from '@/components/ui/VideoList';
 
 const SearchVideosContent = () => {
   const { keyword = '' } = useParams();
@@ -26,9 +27,9 @@ const SearchVideosContent = () => {
     <>
       {error && <Error />}
       {isLoading && <Loading />}
-      <ul className='grid grid-cols-1 gap-y-4 sm:grid-cols-2 sm:gap-x-4 sm:gap-y-10 lg:grid-cols-3 2xl:grid-cols-4'>
-        {data && data.map((item, index) => <VideoCard key={`search-${index}`} video={item} style='' />)}
-      </ul>
+      <VideoListContainer>
+        {data && data.map((item, index) => <VideoList key={`search-${index}`} video={item} />)}
+      </VideoListContainer>
     </>
   );
 };

--- a/src-ts/components/ui/VideoCard.tsx
+++ b/src-ts/components/ui/VideoCard.tsx
@@ -4,7 +4,7 @@ import { publishedDate } from '@/utils/publishedData';
 
 interface VideoProps extends VideoItem {}
 
-const VideoCard = ({ video, style }: { video: VideoProps; style: string }) => {
+const VideoCard = ({ video }: { video: VideoProps }) => {
   const { id } = video;
   const { channelTitle, publishedAt, title, thumbnails, description } = video.snippet;
 
@@ -13,20 +13,10 @@ const VideoCard = ({ video, style }: { video: VideoProps; style: string }) => {
   )},${Math.floor(Math.random() * 128 + 100)})`;
 
   return (
-    <li className={`${style}`}>
-      <Link
-        to={`/videos/watch/${id}`}
-        state={{ video }}
-        className={`flex ${style ? 'flex-col sm:flex-row' : 'flex flex-col'}`}
-      >
-        <div
-          className={`thumbnail ${
-            style
-              ? 'flex-none w-full max-w-full min-w-full sm:w-2/5 sm:max-w-[360px] sm:min-w-[180px]'
-              : 'flex justify-center items-start w-full'
-          }`}
-        >
-          <div className={`thumbnailBox w-full rounded-2xl  overflow-hidden aspect-video`}>
+    <li>
+      <Link to={`/videos/watch/${id}`} state={{ video }} className='flex flex-col'>
+        <div className='flex justify-center items-start w-full'>
+          <div className={`w-full rounded-2xl  overflow-hidden aspect-video`}>
             <img
               src={`${thumbnails.medium.url}`}
               className='w-full h-full object-cover'
@@ -34,36 +24,20 @@ const VideoCard = ({ video, style }: { video: VideoProps; style: string }) => {
             />
           </div>
         </div>
-        <div
-          className={`info flex ${
-            style
-              ? 'flex-row pt-2 sm:flex-col sm:py-0 sm:pt-0 sm:pl-4 md:py-2 md:pl-6'
-              : 'items-start pt-2'
-          }`}
-        >
+        <div className='info flex items-start pt-2'>
           <div
-            className={`channelImg flex-none w-[2rem] h-[2rem] mr-2 text-lg font-bold text-white text-center leading-[2rem] rounded-full overflow-hidden ${
-              style ? 'block sm:hidden' : ''
-            }`}
+            className='channelImg flex-none w-[2rem] h-[2rem] mr-2 text-lg font-bold text-white text-center leading-[2rem] rounded-full overflow-hidden'
             style={{ backgroundColor: `${channerColor}` }}
           >
             {channelTitle.charAt(0).toUpperCase()}
           </div>
           <div>
-            <p
-              className={`title font-bold text-neutral-950 dark:font-semibold dark:text-neutral-100 ${
-                style
-                  ? 'text-lg line-clamp-1 sm:pt-0 lg:line-clamp-2'
-                  : 'mb-1 text-base leading-5 line-clamp-2'
-              }`}
-            >
+            <p className='title font-bold text-neutral-950 dark:font-semibold dark:text-neutral-100 mb-1 text-base leading-5 line-clamp-2'>
               {title.replace(/&#39;/gi, "'").replace(/&quot;/gi, '"')}
             </p>
-            <div className={`channelInfo ${style ? 'flex items-center' : ''}`}>
+            <div>
               <div
-                className={`channelImg flex-none w-[2rem] h-[2rem] mr-2 text-lg font-bold text-white text-center leading-[2rem] rounded-full overflow-hidden ${
-                  style ? 'hidden sm:block' : 'hidden'
-                }`}
+                className='channelImg flex-none w-[2rem] h-[2rem] mr-2 text-lg font-bold text-white text-center leading-[2rem] rounded-full overflow-hidden hidden'
                 style={{ backgroundColor: `${channerColor}` }}
               >
                 {channelTitle.charAt(0).toUpperCase()}
@@ -72,22 +46,10 @@ const VideoCard = ({ video, style }: { video: VideoProps; style: string }) => {
                 {channelTitle}
               </p>
             </div>
-            <p
-              className={`publishedAt text-[#888888] ${
-                style ? 'text-sm pt-0 sm:pt-3' : 'text-sm font-medium leading-5'
-              }`}
-            >
+            <p className='text-[#888888] text-sm font-medium leading-5'>
               {publishedDate(publishedAt)}
             </p>
-            <p
-              className={`description text-[#888888] ${
-                style
-                  ? 'text-sm  max-sm:hidden sm:pt-0 sm:line-clamp-1 md:pt-1 lg:line-clamp-2'
-                  : 'hidden'
-              }`}
-            >
-              {description}
-            </p>
+            <p className='text-[#888888] hidden'>{description}</p>
           </div>
         </div>
       </Link>

--- a/src-ts/components/ui/VideoCard.tsx
+++ b/src-ts/components/ui/VideoCard.tsx
@@ -2,9 +2,7 @@ import { Link } from 'react-router-dom';
 import { VideoItem } from '@/domain/Video';
 import { publishedDate } from '@/utils/publishedData';
 
-interface VideoProps extends VideoItem {}
-
-const VideoCard = ({ video }: { video: VideoProps }) => {
+const VideoCard = ({ video }: { video: VideoItem }) => {
   const { id } = video;
   const { channelTitle, publishedAt, title, thumbnails, description } = video.snippet;
 

--- a/src-ts/components/ui/VideoCardContainer.tsx
+++ b/src-ts/components/ui/VideoCardContainer.tsx
@@ -1,0 +1,9 @@
+const VideoCardContainer = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <ul className='grid grid-cols-1 gap-y-4 sm:grid-cols-2 sm:gap-x-4 sm:gap-y-10 lg:grid-cols-3 2xl:grid-cols-4'>
+      {children}
+    </ul>
+  );
+};
+
+export default VideoCardContainer;

--- a/src-ts/components/ui/VideoCardContainer.tsx
+++ b/src-ts/components/ui/VideoCardContainer.tsx
@@ -1,12 +1,12 @@
-const VideoCardContainer = ({ children }: { children: React.ReactNode }) => {
-<<<<<<< HEAD
-=======
-  console.log('VideoCardContainer');
+import { VideoItem } from '@/domain/Video';
+import VideoCard from '@/components/ui/VideoCard';
 
->>>>>>> 0c6215d (RY-58 refactor: video card divide)
+const VideoCardContainer = ({ videos }: { videos: VideoItem<string>[] }) => {
   return (
     <ul className='grid grid-cols-1 gap-y-4 sm:grid-cols-2 sm:gap-x-4 sm:gap-y-10 lg:grid-cols-3 2xl:grid-cols-4'>
-      {children}
+      {videos.map((item) => (
+        <VideoCard key={item.id} video={item} />
+      ))}
     </ul>
   );
 };

--- a/src-ts/components/ui/VideoCardContainer.tsx
+++ b/src-ts/components/ui/VideoCardContainer.tsx
@@ -1,4 +1,9 @@
 const VideoCardContainer = ({ children }: { children: React.ReactNode }) => {
+<<<<<<< HEAD
+=======
+  console.log('VideoCardContainer');
+
+>>>>>>> 0c6215d (RY-58 refactor: video card divide)
   return (
     <ul className='grid grid-cols-1 gap-y-4 sm:grid-cols-2 sm:gap-x-4 sm:gap-y-10 lg:grid-cols-3 2xl:grid-cols-4'>
       {children}

--- a/src-ts/components/ui/VideoList.tsx
+++ b/src-ts/components/ui/VideoList.tsx
@@ -1,0 +1,58 @@
+import { Link } from 'react-router-dom';
+import { VideoItem } from '@/domain/Video';
+import { publishedDate } from '@/utils/publishedData';
+
+interface videoProps extends VideoItem<string> {}
+
+const VideoList = ({ video }: { video: videoProps }) => {
+  const { id } = video;
+  const { channelTitle, publishedAt, title, thumbnails, description } = video.snippet;
+
+  const channerColor = `rgb(${Math.floor(Math.random() * 128 + 100)},${Math.floor(
+    Math.random() * 128 + 100
+  )},${Math.floor(Math.random() * 128 + 100)})`;
+
+  return (
+    <li>
+      <Link to={`/videos/watch/${id}`} state={{ video }} className='flex flex-col sm:flex-row'>
+        <div className='flex-none w-full max-w-full min-w-full sm:w-2/5 sm:max-w-[360px] sm:min-w-[180px]'>
+          <div className='w-full rounded-2xl  overflow-hidden aspect-video'>
+            <img
+              src={`${thumbnails.medium.url}`}
+              className='w-full h-full object-cover'
+              alt='섬네일 이미지'
+            />
+          </div>
+        </div>
+        <div className='flex-row pt-2 sm:flex-col sm:py-0 sm:pt-0 sm:pl-4 md:py-2 md:pl-6'>
+          <div
+            className='block flex-none w-[2rem] h-[2rem] mr-2 text-lg font-bold text-white text-center leading-[2rem] rounded-full overflow-hidden sm:hidden'
+            style={{ backgroundColor: `${channerColor}` }}
+          >
+            {channelTitle.charAt(0).toUpperCase()}
+          </div>
+          <div>
+            <p className='font-bold text-neutral-950 dark:font-semibold dark:text-neutral-100 text-lg line-clamp-1 sm:pt-0 lg:line-clamp-2'>
+              {title.replaceAll(/&#39;/gi, "'").replaceAll(/&quot;/gi, '"')}
+            </p>
+            <div className={'flex items-center'}>
+              <div
+                className='flex-none w-[2rem] h-[2rem] mr-2 text-lg font-bold text-white text-center leading-[2rem] rounded-full overflow-hidden hidden sm:block'
+                style={{ backgroundColor: `${channerColor}` }}
+              >
+                {channelTitle.charAt(0).toUpperCase()}
+              </div>
+              <p className='text-sm font-medium leading-5 text-[#888888]'>{channelTitle}</p>
+            </div>
+            <p className='text-[#888888] text-sm pt-0 sm:pt-3'>{publishedDate(publishedAt)}</p>
+            <p className='description text-[#888888] text-sm  max-sm:hidden sm:pt-0 sm:line-clamp-1 md:pt-1 lg:line-clamp-2'>
+              {description}
+            </p>
+          </div>
+        </div>
+      </Link>
+    </li>
+  );
+};
+
+export default VideoList;

--- a/src-ts/components/ui/VideoList.tsx
+++ b/src-ts/components/ui/VideoList.tsx
@@ -2,9 +2,7 @@ import { Link } from 'react-router-dom';
 import { VideoItem } from '@/domain/Video';
 import { publishedDate } from '@/utils/publishedData';
 
-interface videoProps extends VideoItem<string> {}
-
-const VideoList = ({ video }: { video: videoProps }) => {
+const VideoList = ({ video }: { video: VideoItem<string> }) => {
   const { id } = video;
   const { channelTitle, publishedAt, title, thumbnails, description } = video.snippet;
 

--- a/src-ts/components/ui/VideoListContainer.tsx
+++ b/src-ts/components/ui/VideoListContainer.tsx
@@ -1,5 +1,14 @@
-const VideoListContainer = ({ children }: { children: React.ReactNode }) => {
-  return <ul className='grid grid-cols-1 gap-y-4 max-w-6xl m-auto'>{children}</ul>;
+import { VideoItem } from '@/domain/Video';
+import VideoList from '@/components/ui/VideoList';
+
+const VideoListContainer = ({ videos }: { videos: VideoItem<string>[] }) => {
+  return (
+    <ul className='grid grid-cols-1 gap-y-4 max-w-6xl m-auto'>
+      {videos.map((item) => (
+        <VideoList key={item.id} video={item} />
+      ))}
+    </ul>
+  );
 };
 
 export default VideoListContainer;

--- a/src-ts/components/ui/VideoListContainer.tsx
+++ b/src-ts/components/ui/VideoListContainer.tsx
@@ -1,0 +1,5 @@
+const VideoListContainer = ({ children }: { children: React.ReactNode }) => {
+  return <ul className='grid grid-cols-1 gap-y-4 max-w-6xl m-auto'>{children}</ul>;
+};
+
+export default VideoListContainer;

--- a/src-ts/service/SearchService.ts
+++ b/src-ts/service/SearchService.ts
@@ -15,12 +15,12 @@ type SearchListRes = {
 };
 
 const getSearchList = async (keyword: string): Promise<SearchListRes> =>
-  await youtubeV3Client
-    .get<SearchListRes>('search', { params: { maxResults: 1, q: keyword } } as Params)
+  // await youtubeV3Client
+  //   .get<SearchListRes>('search', { params: { maxResults: 1, q: keyword } } as Params)
+  //   .then((response) => response.data);
+  await youtubeMockUpClient
+    .get<SearchListRes>('/data/keyword_bts.json')
     .then((response) => response.data);
-//   await youtubeMockUpClient
-//     .get<SearchListRes>('/data/keyword_bts.json')
-//     .then((response) => response.data);
 
 const api = { getSearchList };
 


### PR DESCRIPTION
해당(RY-58) 브런치는 RY-44(base) 하위의 브런치로 RY-44가 먼저 병합되어야 합니다. [RY-44](https://github.com/pmmpmm/react-youtube/pull/23)

**비디오 카드 컴포넌트**
- 한페이지에서 분기로 나누었던 비디오 리스트를 ui에 따라 컴포넌트 분리
- 카드 컴포넌트의 ui에 따른 부모 컴포넌트 생성

[RY-44]: https://pmmpmm85.atlassian.net/browse/RY-44?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ