### PR TITLE
RY-63 refactor: nav active

### DIFF
--- a/src-ts/components/features/Nav.tsx
+++ b/src-ts/components/features/Nav.tsx
@@ -1,6 +1,5 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useRef } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { useParams, useLocation } from 'react-router-dom';
 import { GoHome, GoSmiley } from 'react-icons/go';
 import { IoIosMenu } from 'react-icons/io';
 import { FaSmile } from 'react-icons/fa';
@@ -48,35 +47,18 @@ interface NavProps {
   isNavOpen: boolean;
   setIsNavOpen: React.Dispatch<React.SetStateAction<boolean>>;
   mobileScreenX: boolean;
-}
-interface RouteState {
-  pathname: string;
+  navMenu: string;
 }
 
 const Nav = (props: NavProps) => {
   const navRef = useRef<HTMLElement>(null);
-  const [navMenu, setNavMenu] = useState(navs[0].name);
   const navigate = useNavigate();
-  const { pathname } = useLocation() as RouteState;
-  const { keyword } = useParams();
 
   const handleNavLink = (name: string) => {
     navigate(name === 'home' ? '/' : `/page/${name}`);
-    setNavMenu(name);
   };
 
-  //화면의 경로에 따른 nav menu active ON
-  const navActiveHandle = (pathname: string, keyword?: string) => {
-    navs.map((nav) =>
-      pathname === `/page/${nav.name}`
-        ? setNavMenu(nav.name)
-        : pathname === '/' && setNavMenu('home')
-    );
-    // 상세페이지,검색 결과 페이지 진입 → nav 메뉴 active OFF
-    if (pathname.includes('watch') || keyword) setNavMenu('');
-  };
-
-  // TODO: handleNavClick 리팩토링 필요
+  // TODO: handleNavClick  리팩토링 필요
   //모바일 nav open → nav 클릭 영역에 따른 close 혹은 open
   const handleNavClick = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
     const nav = navRef.current && navRef.current;
@@ -87,14 +69,10 @@ const Nav = (props: NavProps) => {
     }
   };
 
-  useEffect(() => {
-    navActiveHandle(pathname, keyword);
-  }, [keyword, pathname]);
-
   return (
     <div
       onClick={(e) => handleNavClick(e)}
-      className={`nav-wrap flex-none h-full fixed top-0 left-0 z-50 sm:z-0 
+      className={`flex-none h-full fixed top-0 left-0 z-50 sm:z-0 
       ${
         props.isNavOpen &&
         `before:content-[''] before:block before:w-full before:h-full before:bg-black/[.30] before:backdrop-blur-[2px] before:fixed before:top-0 before:left-0 before:z-0`
@@ -120,43 +98,42 @@ const Nav = (props: NavProps) => {
             <IoIosMenu className='w-8 h-8 m-auto text-black dark:text-white' />
           </button>
           <Link to='/' className='flex-none w-[7.5rem] text-[0]'>
-            <h1 className='logo'>
+            <h1>
               <Logo />
             </h1>
           </Link>
         </div>
 
-        <ul className='navList px-1 sm:px-0'>
-          {navs.map((nav, idx) => {
-            return (
-              <li key={idx} className='py-1'>
+        <ul className='px-1 sm:px-0'>
+          {navs.map((nav, idx) => (
+            <li key={idx} className='py-1'>
+              {props.navMenu === nav.name ? (
                 <button
-                  className={`${
-                    nav.name
-                  } btn flex flex-row items-center w-full px-2 py-[0.625rem] rounded-lg sm:flex-col xl:flex-row
-                    ${
-                      navMenu === nav.name &&
-                      'bg-neutral-100 sm:bg-white xl:bg-neutral-100 dark:bg-neutral-800 dark:sm:bg-[#171717]'
-                    }`}
+                  className='flex flex-row items-center w-full px-2 py-[0.625rem] rounded-lg sm:flex-col xl:flex-row bg-neutral-100 sm:bg-white xl:bg-neutral-100 dark:bg-neutral-800 dark:sm:bg-[#171717]'
                   onClick={() => handleNavLink(nav.name)}
                 >
-                  <span className='icon flex justify-center items-center w-[1.625rem] h-[1.625rem] mr-3 sm:mr-0 xl:mr-3'>
-                    {navMenu === nav.name ? nav.actionIcon : nav.icon}
+                  <span className='flex justify-center items-center w-[1.625rem] h-[1.625rem] mr-3 sm:mr-0 xl:mr-3'>
+                    {nav.actionIcon}
                   </span>
-                  <span
-                    className={`tx block pt-0 text-sm sm:text-xs sm:pt-1 xl:text-sm xl:pt-0 xl:font-medium 
-                    ${
-                      navMenu === nav.name
-                        ? ' font-semibold text-neutral-950 dark:text-white'
-                        : 'font-medium text-neutral-800 dark:text-neutral-300'
-                    }`}
-                  >
+                  <span className='block pt-0 text-sm sm:text-xs sm:pt-1 xl:text-sm xl:pt-0 xl:font-medium font-semibold text-neutral-950 dark:text-white'>
                     {nav.title}
                   </span>
                 </button>
-              </li>
-            );
-          })}
+              ) : (
+                <button
+                  className='flex flex-row items-center w-full px-2 py-[0.625rem] rounded-lg sm:flex-col xl:flex-row'
+                  onClick={() => handleNavLink(nav.name)}
+                >
+                  <span className='flex justify-center items-center w-[1.625rem] h-[1.625rem] mr-3 sm:mr-0 xl:mr-3'>
+                    {nav.icon}
+                  </span>
+                  <span className='block pt-0 text-sm sm:text-xs sm:pt-1 xl:text-sm xl:pt-0 xl:font-medium font-medium text-neutral-800 dark:text-neutral-300'>
+                    {nav.title}
+                  </span>
+                </button>
+              )}
+            </li>
+          ))}
         </ul>
       </nav>
     </div>

--- a/src-ts/components/features/common/layouts/LayoutA.tsx
+++ b/src-ts/components/features/common/layouts/LayoutA.tsx
@@ -1,4 +1,5 @@
 import { ReactElement, useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { screens } from 'tailwindcss/defaultTheme';
 import { IoIosMenu } from 'react-icons/io';
 import Header from '@/components/features/Header';
@@ -12,6 +13,8 @@ const LayoutA = ({ children }: LayoutAProps) => {
   const screenX = window.matchMedia(`(max-width: ${screens.sm})`);
   const [mobileScreenX, setMobileScreenX] = useState(screenX.matches);
   const [isNavOpen, setIsNavOpen] = useState<boolean>(false);
+  const [navMenu, setNavMenu] = useState('/');
+  const { pathname = '' } = useLocation();
 
   useEffect(() => {
     // 화면 가로사이즈 resize
@@ -21,9 +24,17 @@ const LayoutA = ({ children }: LayoutAProps) => {
     });
   }, []);
 
+  useEffect(() => {
+    const pathArray = pathname.split('/').slice(1);
+    if (pathArray.includes('page') || pathArray.length === 1) {
+      let path = pathArray.slice(-1)[0];
+      path = path ? path : 'home';
+      setNavMenu(path);
+    }
+  }, [pathname]);
+
   return (
     <>
-      {/* Header */}
       <div className='w-full flex flex-row items-center justify-between px-2 h-header-height bg-white fixed top-0 left-0 z-50 dark:bg-[#171717] sm:h-header-height-sm sm:px-4'>
         {/* nav menu btn */}
         <button
@@ -36,8 +47,12 @@ const LayoutA = ({ children }: LayoutAProps) => {
         <Header />
       </div>
 
-      {/* LNB */}
-      <Nav isNavOpen={isNavOpen} setIsNavOpen={setIsNavOpen} mobileScreenX={mobileScreenX} />
+      <Nav
+        isNavOpen={isNavOpen}
+        setIsNavOpen={setIsNavOpen}
+        mobileScreenX={mobileScreenX}
+        navMenu={navMenu}
+      />
 
       {/* contents */}
       <div className='flex pt-container-top pb-8 sm:pt-container-top-sm'>

--- a/src-ts/components/ui/Message.tsx
+++ b/src-ts/components/ui/Message.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { BiMessageSquareError } from 'react-icons/bi';
 import { TbFaceIdError } from 'react-icons/tb';
-import LoadingIcon from './LoadingIcon';
+import LoadingIcon from '@/components/ui/LoadingIcon';
 
 interface Props {
   type: string;


### PR DESCRIPTION
해당(RY-63) 브런치는 RY-58(base) 하위의 브런치로 RY-58가 먼저 병합되어야 합니다. [RY-58](https://github.com/pmmpmm/react-youtube/pull/24)

**Nav 버튼 active**
- 페이지 상태를 외부에서 주입 받아  버튼 활성화

**import 경로**
- 상대경로를 절대경로로 수정

[RY-58]: https://pmmpmm85.atlassian.net/browse/RY-58?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ